### PR TITLE
Agent Rate Limit

### DIFF
--- a/amplify/functions/utils/cdkUtils.ts
+++ b/amplify/functions/utils/cdkUtils.ts
@@ -84,6 +84,17 @@ export const addLlmAgentPolicies = (props: {
         }),
     )
 
+    // Add SSM permissions
+    props.role.addToPrincipalPolicy(new cdk.aws_iam.PolicyStatement({
+        actions: [
+            "ssm:GetParameter",
+            "ssm:GetParameters",
+        ],
+        resources: [
+            `arn:aws:ssm:${props.rootStack.region}:${props.rootStack.account}:parameter/*`
+        ],
+    }))
+
     props.role.addToPrincipalPolicy(new cdk.aws_iam.PolicyStatement({
         actions: [
             "s3:GetBucketLocation",

--- a/src/utils/rateLimiter.ts
+++ b/src/utils/rateLimiter.ts
@@ -1,0 +1,78 @@
+import { SSMClient, GetParameterCommand } from '@aws-sdk/client-ssm';
+
+export class RateLimiter {
+    private static instance: RateLimiter;
+    private lastInvocationTime: number | null = null;
+    private rateLimitSeconds: number;
+
+    private static async initializeRateLimit(): Promise<number> {
+        const ssm = new SSMClient({});
+        const parameterPath = 'AGENT_RATE_LIMIT';
+        console.log(`RateLimiter: Attempting to fetch rate limit from Parameter Store at path: ${parameterPath}`);
+        const startTime = Date.now();
+
+        try {
+            const command = new GetParameterCommand({
+                Name: parameterPath,
+                WithDecryption: false
+            });
+            const result = await ssm.send(command);
+            const fetchDuration = Date.now() - startTime;
+
+            if (!result.Parameter?.Value) {
+                console.log('RateLimiter: No rate limit value found in Parameter Store');
+                console.log(`RateLimiter: Parameter Store fetch took ${fetchDuration}ms`);
+                return 0;
+            }
+
+            const rateLimit = parseInt(result.Parameter.Value);
+            if (isNaN(rateLimit)) {
+                console.error(`RateLimiter: Invalid rate limit value: ${result.Parameter.Value}. Using default rate limit of 0 seconds.`);
+                return 0;
+            }
+
+            console.log(`RateLimiter: Found rate limit value: ${rateLimit} seconds`);
+            console.log(`RateLimiter: Parameter Store fetch took ${fetchDuration}ms`);
+            return rateLimit;
+        } catch (error) {
+            const fetchDuration = Date.now() - startTime;
+            console.error('RateLimiter: Error fetching rate limit from Parameter Store:', error);
+            console.log(`RateLimiter: Parameter Store fetch took ${fetchDuration}ms`);
+            return 0;
+        }
+    }
+
+    private constructor() {
+        this.rateLimitSeconds = 0;
+    }
+
+    public static async getInstance(): Promise<RateLimiter> {
+        if (!RateLimiter.instance) {
+            RateLimiter.instance = new RateLimiter();
+            RateLimiter.instance.rateLimitSeconds = await RateLimiter.initializeRateLimit();
+        }
+        return RateLimiter.instance;
+    }
+
+    public async waitForRateLimit(): Promise<void> {
+        if (this.rateLimitSeconds <= 0) {
+            console.log('RateLimiter: Skipping rate limiting as it is not configured.');
+            return;
+        }
+
+        const now = Date.now();
+        if (this.lastInvocationTime !== null) {
+            const timeSinceLastInvocation = now - this.lastInvocationTime;
+            const waitTime = Math.max(0, (this.rateLimitSeconds * 1000) - timeSinceLastInvocation);
+
+            if (waitTime > 0) {
+                console.log(`RateLimiter: Pausing for ${waitTime}ms due to rate limit threshold being met`);
+                await new Promise(resolve => setTimeout(resolve, waitTime));
+            } else {
+                console.log(`RateLimiter: Below threshold (last call ${timeSinceLastInvocation}ms ago)`);
+            }
+        }
+
+        this.lastInvocationTime = now;
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

In case it's useful, a rate limit option for Agents. To enable it, add a parameter in AWS Parameter Store with the name AGENT_RATE_LIMIT, and a value of an integer.
The value is the minimum seconds between Agent invocations.
The Rate Limit is only active if the Parameter exists and is a positive integer. Otherwise it is not active.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
