### PR TITLE
Add Node.js 20 support for Amplify deployment

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -4,15 +4,31 @@ backend:
     preBuild:
       commands:
         - echo "Build environment is $CODEBUILD_BUILD_IMAGE"
-        # - aws ecr-public get-login-password | docker login --username AWS --password-stdin public.ecr.aws
+        - echo "Current Node version:"
+        - node --version
+        - echo "Installing Node.js 20 from binary..."
+        - curl -fsSL https://nodejs.org/dist/v20.18.1/node-v20.18.1-linux-x64.tar.xz -o node.tar.xz
+        - tar -xf node.tar.xz
+        - export PATH=$(pwd)/node-v20.18.1-linux-x64/bin:$PATH
+        - node --version
+        - npm --version
+        - docker --version
     build:
       commands:
+        - export PATH=$(pwd)/node-v20.18.1-linux-x64/bin:$PATH
         - npm ci --cache .npm --prefer-offline
         - npx ampx pipeline-deploy --branch $AWS_BRANCH --app-id $AWS_APP_ID --debug
 frontend:
   phases:
+    preBuild:
+      commands:
+        - echo "Setting up Node.js 20 for frontend..."
+        - export PATH=$(pwd)/node-v20.18.1-linux-x64/bin:$PATH
+        - node --version
+        - npm --version
     build:
       commands:
+        - export PATH=$(pwd)/node-v20.18.1-linux-x64/bin:$PATH
         - npm run build
   artifacts:
     baseDirectory: .next

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "agents-for-energy",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "scripts": {
     "ecrAuth": "aws ecr-public get-login-password | docker login --username AWS --password-stdin public.ecr.aws",
     "cdkDiff": "cdk diff --ci --app \"npx tsx amplify/backend.ts\" --output .amplify/artifacts/cdk.out --context amplify-backend-name=$(whoami) --context amplify-backend-namespace=$(node -e \"console.log(require('./package.json').name)\") --context amplify-backend-type=sandbox",


### PR DESCRIPTION
*Issue #, if available:* Deployment fails because of Node version incompatibility with Amplify SSR hosting

*Description of changes:* Install Node.js 20 in build phase


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
