### PR TITLE
Add e2e test verifying AG-UI binary event stream during chat

### DIFF
--- a/web/e2e/chat.spec.ts
+++ b/web/e2e/chat.spec.ts
@@ -30,4 +30,38 @@ test.describe('Chat page', () => {
     // Submit button should return to idle state once streaming finishes
     await expect(page.getByRole('button', { name: 'Submit' })).toBeVisible({ timeout: 60_000 });
   });
+
+  test('agent response streams over the AG-UI binary event stream protocol', async ({ page }) => {
+    const invokeResponsePromise = page.waitForResponse(
+      (response) => response.url().includes('/harnesses/invoke') && response.request().method() === 'POST',
+    );
+
+    const textarea = page.getByRole('textbox', { name: 'message' });
+    await textarea.fill('Say exactly: hello');
+    await textarea.press('Enter');
+
+    // User bubble appears immediately, and the submit button flips to "Stop"
+    // synchronously with the send — before any network round trip completes.
+    await expect(page.locator('[data-testid="message-user"]').last()).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Stop' })).toBeVisible();
+
+    // The "Thinking…" shimmer is the loading state shown while waiting for the first token.
+    await expect(page.getByText('Thinking…')).toBeVisible({ timeout: 10_000 });
+
+    // Confirm the harness responded with the raw AWS binary event stream — not a
+    // buffered JSON blob — which is what the custom ChatTransport decodes frame by frame.
+    const invokeResponse = await invokeResponsePromise;
+    expect(invokeResponse.headers()['content-type']).toContain('application/vnd.amazon.eventstream');
+
+    // The assistant message appears as soon as the transport enqueues its first
+    // chunk (right after the response headers land, before any text has streamed
+    // in) — well before the submit button has a chance to return to idle.
+    const assistantMessage = page.locator('[data-testid="message-assistant"]').last();
+    await expect(assistantMessage).toBeVisible({ timeout: 60_000 });
+    await expect(page.getByRole('button', { name: 'Stop' })).toBeVisible();
+
+    // Once streaming completes: shimmer is gone and the submit button returns to idle.
+    await expect(page.getByText('Thinking…')).not.toBeVisible();
+    await expect(page.getByRole('button', { name: 'Submit' })).toBeVisible({ timeout: 60_000 });
+  });
 });


### PR DESCRIPTION
Reconstructed from source PR `waltmayf/agentcore-amplify-fullstack#40` (the original could not be transferred across repos during the migration; the branch was re-imported and rebased onto the new `main`).

## What this does
Extends `web/e2e/chat.spec.ts` with a test that explicitly verifies the AG-UI binary event stream protocol:

- Intercepts the `POST /harnesses/invoke` response and asserts `Content-Type: application/vnd.amazon.eventstream`.
- Asserts the "Thinking…" shimmer and a partial/streaming assistant message appear while the submit button is still "Stop" (before the response completes).
- Asserts the shimmer disappears and the submit button returns to idle ("Submit") once streaming finishes.

## Related issues
- Closes #146 (*Strengthen chat E2E test to verify AG-UI event stream*)

<sub>Migration context: original commit authored by `claude[bot]` on 2026-07-02. See PR-snapshot issue #173.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)